### PR TITLE
adjusting layout with vertical account actions to save space

### DIFF
--- a/components/nav-bar/nav.tsx
+++ b/components/nav-bar/nav.tsx
@@ -77,9 +77,6 @@ const Nav: FC<NavProps> = ({onClose, children}) => {
               <UserAvatar />
             </NavMenuItem>
             <div>
-              <NavMenuItem as="li" fontWeight="bold">
-                <Link href="/api/logout">Log out</Link>
-              </NavMenuItem>
               <Can I="read" a="keystone">
                 <NavMenuItem as="li" fontWeight="bold">
                   <Link href="/keystone" isInternal={false}>
@@ -89,6 +86,9 @@ const Nav: FC<NavProps> = ({onClose, children}) => {
               </Can>
               <NavMenuItem as="li" fontWeight="bold">
                 <Link href="/my-account">My account</Link>
+              </NavMenuItem>
+              <NavMenuItem as="li" fontWeight="bold">
+                <Link href="/api/logout">Log out</Link>
               </NavMenuItem>
             </div>
           </>

--- a/components/nav-bar/nav.tsx
+++ b/components/nav-bar/nav.tsx
@@ -69,30 +69,28 @@ const Nav: FC<NavProps> = ({onClose, children}) => {
         {() => (
           <>
             <NavMenuItem as="li" fontWeight="bold">
-              <Link href="/api/logout">Log out</Link>
-            </NavMenuItem>
-            <NavMenuItem as="li" fontWeight="bold">
               <Link href="/short-list">
                 Short list ({data.me.shortlist.length})
               </Link>
             </NavMenuItem>
-            {isMedium && (
-              <>
-                <Can I="read" a="keystone">
-                  <NavMenuItem as="li" fontWeight="bold">
-                    <Link href="/keystone" isInternal={false}>
-                      Admin
-                    </Link>
-                  </NavMenuItem>
-                </Can>
-                <NavMenuItem as="li" fontWeight="bold">
-                  <Link href="/my-account">My account</Link>
-                </NavMenuItem>
-              </>
-            )}
             <NavMenuItem as="li">
               <UserAvatar />
             </NavMenuItem>
+            <div>
+              <NavMenuItem as="li" fontWeight="bold">
+                <Link href="/api/logout">Log out</Link>
+              </NavMenuItem>
+              <Can I="read" a="keystone">
+                <NavMenuItem as="li" fontWeight="bold">
+                  <Link href="/keystone" isInternal={false}>
+                    Admin
+                  </Link>
+                </NavMenuItem>
+              </Can>
+              <NavMenuItem as="li" fontWeight="bold">
+                <Link href="/my-account">My account</Link>
+              </NavMenuItem>
+            </div>
           </>
         )}
       </Can>


### PR DESCRIPTION
<img width="1347" alt="image" src="https://user-images.githubusercontent.com/15904136/73447077-1c85ec80-43b2-11ea-9861-7eb5edbf1a4d.png">
Much tidier this way IMO. Works better on smaller screens too:
<img width="1257" alt="image" src="https://user-images.githubusercontent.com/15904136/73447283-7dadc000-43b2-11ea-9dbf-1c65743beb2d.png">
