### PR TITLE
menu restructure

### DIFF
--- a/lib/graphql/gen-types.ts
+++ b/lib/graphql/gen-types.ts
@@ -54,6 +54,12 @@ export type Category = Document & {
   parent?: Maybe<Category>,
 };
 
+export type ChildPage = {
+   __typename?: 'ChildPage',
+  childPage?: Maybe<ChildPageReference>,
+  alternateText?: Maybe<Scalars['String']>,
+};
+
 export type ChildPageReference = PageContent | Hymn | Prayer | Liturgy | Scripture | Asset;
 
 export type Copyright = Document & {
@@ -256,7 +262,7 @@ export type MenuItem = {
    __typename?: 'MenuItem',
   _key?: Maybe<Scalars['String']>,
   text?: Maybe<Scalars['String']>,
-  childpages?: Maybe<Array<Maybe<ChildPageReference>>>,
+  childpages?: Maybe<Array<Maybe<ChildPage>>>,
 };
 
 export type Metre = Document & {
@@ -703,6 +709,7 @@ export type ResolversTypes = {
   ExternalUrl: ResolverTypeWrapper<any>,
   RelativeUrl: ResolverTypeWrapper<any>,
   MenuItem: ResolverTypeWrapper<any>,
+  ChildPage: ResolverTypeWrapper<any>,
   ChildPageReference: ResolverTypeWrapper<any>,
   OccasionGroupedById: ResolverTypeWrapper<any>,
   FilterInput: ResolverTypeWrapper<any>,
@@ -753,6 +760,7 @@ export type ResolversParentTypes = {
   ExternalUrl: any,
   RelativeUrl: any,
   MenuItem: any,
+  ChildPage: any,
   ChildPageReference: any,
   OccasionGroupedById: any,
   FilterInput: any,
@@ -808,6 +816,12 @@ export type CategoryResolvers<ContextType = Context, ParentType extends Resolver
   _updatedAt?: Resolver<Maybe<ResolversTypes['Date']>, ParentType, ContextType>,
   title?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
   parent?: Resolver<Maybe<ResolversTypes['Category']>, ParentType, ContextType>,
+  __isTypeOf?: isTypeOfResolverFn<ParentType>,
+};
+
+export type ChildPageResolvers<ContextType = Context, ParentType extends ResolversParentTypes['ChildPage'] = ResolversParentTypes['ChildPage']> = {
+  childPage?: Resolver<Maybe<ResolversTypes['ChildPageReference']>, ParentType, ContextType>,
+  alternateText?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
   __isTypeOf?: isTypeOfResolverFn<ParentType>,
 };
 
@@ -942,7 +956,7 @@ export type MenuResolvers<ContextType = Context, ParentType extends ResolversPar
 export type MenuItemResolvers<ContextType = Context, ParentType extends ResolversParentTypes['MenuItem'] = ResolversParentTypes['MenuItem']> = {
   _key?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
   text?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
-  childpages?: Resolver<Maybe<Array<Maybe<ResolversTypes['ChildPageReference']>>>, ParentType, ContextType>,
+  childpages?: Resolver<Maybe<Array<Maybe<ResolversTypes['ChildPage']>>>, ParentType, ContextType>,
   __isTypeOf?: isTypeOfResolverFn<ParentType>,
 };
 
@@ -1141,6 +1155,7 @@ export type Resolvers<ContextType = Context> = {
   Asset?: AssetResolvers<ContextType>,
   Author?: AuthorResolvers<ContextType>,
   Category?: CategoryResolvers<ContextType>,
+  ChildPage?: ChildPageResolvers<ContextType>,
   ChildPageReference?: ChildPageReferenceResolvers,
   Copyright?: CopyrightResolvers<ContextType>,
   Date?: GraphQLScalarType,

--- a/lib/graphql/models/resource.ts
+++ b/lib/graphql/models/resource.ts
@@ -43,7 +43,7 @@ export async function main(): Promise<Main> {
     ['*']
       .concat([
         '[_type == "main"][0]',
-        '{_type,blurb,heading,subheading,"menuItems":menuitems[] {...,_type,childpages[]{_type,alternateText,...childPage->{_type,_id,title,name,url}}}}'
+        '{_type,blurb,heading,subheading,"menuItems":menuitems[] {...,_type,childpages[]{_type,alternateText,childPage->{_type,_id,title,name,url}}}}'
       ])
       .join('|')
   );
@@ -54,7 +54,7 @@ export async function menuItems(): Promise<MenuItem[]> {
     ['*']
       .concat([
         '[_type == "main"]',
-        '[0].menuitems[] {...,_type,childpages[]{_type,alternateText,...childPage->{_type,_id,title,name,url}}}'
+        '[0].menuitems[] {...,_type,childpages[]{_type,alternateText,childPage->{_type,_id,title,name,url}}}'
       ])
       .join('|')
   );

--- a/lib/graphql/models/resource.ts
+++ b/lib/graphql/models/resource.ts
@@ -43,7 +43,7 @@ export async function main(): Promise<Main> {
     ['*']
       .concat([
         '[_type == "main"][0]',
-        '{_type,blurb,heading,subheading,"menuItems":menuitems[] {...,_type,childpages[]->{_type,_id,title}}}'
+        '{_type,blurb,heading,subheading,"menuItems":menuitems[] {...,_type,childpages[]{_type,alternateText,...childPage->{_type,_id,title,name,url}}}}'
       ])
       .join('|')
   );
@@ -54,7 +54,7 @@ export async function menuItems(): Promise<MenuItem[]> {
     ['*']
       .concat([
         '[_type == "main"]',
-        '[0].menuitems[] {...,_type,childpages[]->{_type,_id,title}}'
+        '[0].menuitems[] {...,_type,childpages[]{_type,alternateText,...childPage->{_type,_id,title,name,url}}}'
       ])
       .join('|')
   );

--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -216,7 +216,12 @@ export const schema = gql`
   type MenuItem {
     _key: String
     text: String
-    childpages: [ChildPageReference]
+    childpages: [ChildPage]
+  }
+
+  type ChildPage {
+    childPage: ChildPageReference
+    alternateText: String
   }
 
   type Author implements Document {

--- a/src/components/footer/footer.tsx
+++ b/src/components/footer/footer.tsx
@@ -30,14 +30,17 @@ const Footer: FC<FooterProps> = ({menuItems}) => {
             <Grid columns={[1, 2, '1fr 2fr 2fr 1fr']}>
               {menuItems.map(menu => (
                 <Box key={menu._key}>
-                  {menu.text && (
-                    <Styled.p>{menu.text}</Styled.p>
-                  )}
+                  {menu.text && <Styled.p>{menu.text}</Styled.p>}
                   {menu.childpages && (
                     <Styled.ul>
                       {menu.childpages.map(item => (
                         <li key={item._id}>
-                          <Link {...linkProps(item)} />
+                          <Link
+                            {...linkProps({
+                              ...item,
+                              ...item.childPage
+                            })}
+                          />
                         </li>
                       ))}
                     </Styled.ul>

--- a/src/components/link.tsx
+++ b/src/components/link.tsx
@@ -105,11 +105,11 @@ export function scriptureLinkProps({_id, title}: Scripture): LinkProps {
   };
 }
 
-export function assetLinkProps({url, name}: Asset): LinkProps {
+export function assetLinkProps({url, name, alternateText}: Asset): LinkProps {
   return {
     isInternal: false,
     href: url,
-    children: name
+    children: alternateText || name
   };
 }
 

--- a/src/components/nav-bar/nav-items.tsx
+++ b/src/components/nav-bar/nav-items.tsx
@@ -35,11 +35,14 @@ const NavCollapse: FC<NavCollapseProps> = ({text, childpages}) => {
             listStyle: 'none'
           }}
         >
-          {childpages.map(item => (
-            <Text key={item._id} as="li">
-              <Link {...linkProps(item)} variant="nav" />
-            </Text>
-          ))}
+          {childpages.map(item => {
+            console.log(item)
+            return (
+              <Text key={item._id} as="li">
+                <Link {...linkProps(item)} variant="nav" />
+              </Text>
+            );
+          })}
         </Text>
       </Flex>
     </>

--- a/src/components/nav-bar/nav-items.tsx
+++ b/src/components/nav-bar/nav-items.tsx
@@ -36,10 +36,15 @@ const NavCollapse: FC<NavCollapseProps> = ({text, childpages}) => {
           }}
         >
           {childpages.map(item => {
-            console.log(item)
             return (
               <Text key={item._id} as="li">
-                <Link {...linkProps(item)} variant="nav" />
+                <Link
+                  {...linkProps({
+                    ...item,
+                    ...item.childPage
+                  })}
+                  variant="nav"
+                />
               </Text>
             );
           })}
@@ -70,7 +75,6 @@ type NavItemsProps = {
 
 const NavItems: FC<NavItemsProps> = ({selectedMenu, menuItems}) => {
   const isMedium = useResponsiveValue([false, true]);
-
   /* eslint-disable react/jsx-no-useless-fragment */
   return (
     <>

--- a/src/components/queries/home.tsx
+++ b/src/components/queries/home.tsx
@@ -15,6 +15,9 @@ export default gql`
             _id
             _type
             title
+            name?
+            url?
+            alternateText?
           }
         }
       }

--- a/src/components/queries/home.tsx
+++ b/src/components/queries/home.tsx
@@ -11,13 +11,20 @@ export default gql`
         _key
         text
         childpages {
-          ... on PageContent {
-            _id
-            _type
-            title
-            name?
-            url?
-            alternateText?
+          alternateText
+          childPage {
+            ... on PageContent {
+              _id
+              _type
+              title
+            }
+
+            ... on Asset {
+              _id
+              _type
+              name
+              url
+            }
           }
         }
       }

--- a/src/components/queries/index.tsx
+++ b/src/components/queries/index.tsx
@@ -54,6 +54,12 @@ export type Category = Document & {
   parent?: Maybe<Category>,
 };
 
+export type ChildPage = {
+   __typename?: 'ChildPage',
+  childPage?: Maybe<ChildPageReference>,
+  alternateText?: Maybe<Scalars['String']>,
+};
+
 export type ChildPageReference = PageContent | Hymn | Prayer | Liturgy | Scripture | Asset;
 
 export type Copyright = Document & {
@@ -256,7 +262,7 @@ export type MenuItem = {
    __typename?: 'MenuItem',
   _key?: Maybe<Scalars['String']>,
   text?: Maybe<Scalars['String']>,
-  childpages?: Maybe<Array<Maybe<ChildPageReference>>>,
+  childpages?: Maybe<Array<Maybe<ChildPage>>>,
 };
 
 export type Metre = Document & {
@@ -947,9 +953,16 @@ export type HomeQuery = (
       { __typename?: 'MenuItem' }
       & Pick<MenuItem, '_key' | 'text'>
       & { childpages: Maybe<Array<Maybe<(
-        { __typename?: 'PageContent' }
-        & Pick<PageContent, '_id' | '_type' | 'title'>
-      ) | { __typename?: 'Hymn' } | { __typename?: 'Prayer' } | { __typename?: 'Liturgy' } | { __typename?: 'Scripture' } | { __typename?: 'Asset' }>>> }
+        { __typename?: 'ChildPage' }
+        & Pick<ChildPage, 'alternateText'>
+        & { childPage: Maybe<(
+          { __typename?: 'PageContent' }
+          & Pick<PageContent, '_id' | '_type' | 'title'>
+        ) | { __typename?: 'Hymn' } | { __typename?: 'Prayer' } | { __typename?: 'Liturgy' } | { __typename?: 'Scripture' } | (
+          { __typename?: 'Asset' }
+          & Pick<Asset, '_id' | '_type' | 'name' | 'url'>
+        )> }
+      )>>> }
     )>>> }
   )> }
 );
@@ -1859,10 +1872,19 @@ export const HomeDocument = gql`
       _key
       text
       childpages {
-        ... on PageContent {
-          _id
-          _type
-          title
+        alternateText
+        childPage {
+          ... on PageContent {
+            _id
+            _type
+            title
+          }
+          ... on Asset {
+            _id
+            _type
+            name
+            url
+          }
         }
       }
     }


### PR DESCRIPTION
So in order to have files as a menu item, I've needed to restructure the menu schema to allow:
- files (not just references to pages or other content)
- an alternate link string, for the content of the link, as love_worship_4eva_final_actuallyFinal.pdf as the text content of the link isn't great...

Although the schema has been updated with a nesting object, as far as the query to sanity is concerned, I'm spreading the (now nested) ref object onto the childItem, so the title and id are accessible with the same graphql queries as before and nothing needed to change in the menu regarding that.

The issue is that now we also have (in that childItem object) a number of new keys: name, url and alternateText

Currently the menu breaks because when adding those to the gql schema, now there are items which don't possess a name/url or alternateText value, it blows up.

So - we need to ensure all the spread properties are available in the app so I can finish making PDFs accessible directly in menu